### PR TITLE
Cli config param

### DIFF
--- a/src/PBE/CommandLineProcessor/CommandLineOptions.cs
+++ b/src/PBE/CommandLineProcessor/CommandLineOptions.cs
@@ -1,0 +1,27 @@
+﻿using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PBE.CommandLineProcessor
+{
+    public class CommandLineOptions
+    {
+        public const char SEPARATOR = ':';
+        public static readonly string[] EMPTY_ARRAY = new string[0];
+
+        [Option('a', "auto", Required = false, HelpText = "Set automatic mode")]
+        public bool Automatic { get; set; }
+
+        [Option('c', "config", Required = false, HelpText = "Set configuration file to work with. If not set, PBE.xml in the current directory will be used.")]
+        public string ConfigFilePath { get; set; }
+
+        [Option('l', "logDir", Required = false, HelpText = "Set log file.")]
+        public string LogFileDirectory { get; set; }
+
+        [Option('f', "filter", Required = false, HelpText = "Set filter.", Separator = CommandLineOptions.SEPARATOR)]
+        public IEnumerable<string> Filter { get; set; }
+    }
+}

--- a/src/PBE/CommandLineProcessor/CommandLineParser.cs
+++ b/src/PBE/CommandLineProcessor/CommandLineParser.cs
@@ -1,0 +1,53 @@
+﻿using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PBE.CommandLineProcessor
+{
+    public static class CommandLineParser
+    {
+        public static void ParseOptions(string[] args, Action<CommandLineOptions> action)
+        {
+            // Parse legacy options
+            string[] modifiedArgs = ModifyLegacyOptions(args);
+
+            CommandLineOptions options = new CommandLineOptions();
+
+            CommandLine.Parser.Default
+                .ParseArguments<CommandLineOptions>(modifiedArgs)
+                .WithParsed<CommandLineOptions>(o => action(o));
+        }
+
+        private static string[] ModifyLegacyOptions(string[] args)
+        {
+            List<string> modifiedArgs = new List<string>(args.Length);
+            List<string> filters = new List<string>();
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                bool bIsAutomaticArg = "/AUTO".Equals(args[i], StringComparison.OrdinalIgnoreCase);
+                bool bIsFilterArg = "/FILTER".Equals(args[i], StringComparison.OrdinalIgnoreCase);
+
+                if (bIsAutomaticArg) args[i] = "--auto";
+
+                if (!bIsFilterArg)
+                {
+                    modifiedArgs.Add(args[i]);
+                }
+                else if (i <= args.Length)
+                {
+                    filters.Add(args[++i]);
+                }
+            }
+            if (filters.Count > 0)
+            {
+                modifiedArgs.Add("--filter");
+                modifiedArgs.Add(string.Join(CommandLineOptions.SEPARATOR.ToString(), filters));
+            }
+            return modifiedArgs.ToArray();
+        }
+    }
+}

--- a/src/PBE/ExecutableContainer.cs
+++ b/src/PBE/ExecutableContainer.cs
@@ -96,7 +96,7 @@ namespace PBE
 
         public ExecutableContainer(XElement xe)
         {
-            Console.WriteLine("Anayze Parameters...");
+            Console.WriteLine("Analyze parameters...");
             SetParam("Weekday", DateTime.Now.ToString("ddd", System.Globalization.CultureInfo.GetCultureInfo("de-DE")));
             SetParam("Date", DateTime.Now.ToString("yyyyMMdd"));
             SetParam("DateTime", DateTime.Now.ToString("yyyyMMdd-HHmmss"));

--- a/src/PBE/PBE.csproj
+++ b/src/PBE/PBE.csproj
@@ -18,6 +18,21 @@
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -40,6 +55,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=2.3.0.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.3.0\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -58,12 +76,15 @@
     <Compile Include="Actions\ImportQueue.cs" />
     <Compile Include="Actions\MakeDir.cs" />
     <Compile Include="Actions\Publish.cs" />
+    <Compile Include="CommandLineProcessor\CommandLineParser.cs" />
+    <Compile Include="CommandLineProcessor\CommandLineOptions.cs" />
     <Compile Include="Executable.cs" />
     <Compile Include="ExecutableCondition.cs" />
     <Compile Include="ExecutableContainer.cs" />
     <Compile Include="ExecutableParallel.cs" />
     <Compile Include="ExecutableSequence.cs" />
     <Compile Include="HtmlHelper.cs" />
+    <Compile Include="PBEContext.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -76,10 +97,18 @@
       <SubType>Designer</SubType>
     </Content>
     <None Include="App.config" />
+    <None Include="packages.config" />
     <None Include="PBE.dtd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/PBE/PBEContext.cs
+++ b/src/PBE/PBEContext.cs
@@ -1,0 +1,53 @@
+﻿using PBE.CommandLineProcessor;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace PBE
+{
+    public class PBEContext
+    {
+        public static PBEContext CurrentContext { get; private set; }
+
+        public static void Create(CommandLineOptions options)
+        {
+            CurrentContext = new PBEContext(options);
+        }
+
+        public readonly HashSet<string> TaskFilters;
+
+        private PBEContext(CommandLineOptions options)
+        {
+            this.AutomaticMode = options.Automatic;
+            this.TaskFilters = new HashSet<string>(options.Filter);
+            this.ConfigFile = GetPath(options.ConfigFilePath, "PBE.xml", true);
+            this.LogFileDirectory = GetPath(options.LogFileDirectory, Path.GetDirectoryName(options.ConfigFilePath), false);
+        }
+
+        private string GetPath(string optionPath, string defaultPath, bool bIsFile)
+        {
+            string fileName = string.IsNullOrWhiteSpace(optionPath)
+                ? defaultPath : optionPath;
+
+            FileSystemInfo fsi = null;
+            if (File.Exists(fileName))
+                fsi = new FileInfo(fileName);
+            else if (Directory.Exists(fileName))
+                fsi = new DirectoryInfo(fileName);
+
+            if (fsi == null)
+                throw new FileNotFoundException("File not found or not accessible", fileName);
+
+            if (bIsFile && !(fsi is FileInfo))
+                throw new InvalidOperationException(String.Format("'{0}' is not a file", fileName));
+
+            return fsi.FullName;
+        }
+
+        public bool AutomaticMode { get; private set; }
+        public string Filter { get; private set; }
+        public string ConfigFile { get; private set; }
+        public string LogFileDirectory { get; private set; }
+    }
+}

--- a/src/PBE/Program.cs
+++ b/src/PBE/Program.cs
@@ -4,45 +4,21 @@ using System.Diagnostics;
 using System.IO;
 using System.Xml.Linq;
 
+using PBE.CommandLineProcessor;
+
 namespace PBE
 {
-    internal class Program
+    public class Program
     {
-        public static bool Automatic = false;
-        public static string Directory = String.Empty;
-        public static HashSet<String> TaskFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
         private static void Main(string[] args)
         {
-            #region parse Arguments
+            CommandLineParser.ParseOptions(args, RunPBE);
+        }
 
-            if (args.Length >= 1)
-            {
-                for (int i = 0; i < args.Length; i++)
-                {
-                    if ("AUTO".Equals(args[i], StringComparison.OrdinalIgnoreCase))
-                    {
-                        Automatic = true;
-                    }
-
-                    if ("/FILTER".Equals(args[i], StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (i <= args.Length)
-                        {
-                            i++;
-                            TaskFilters.Add(args[i]);
-                        }
-                    }
-                }
-            }
-
-            #endregion parse Arguments
-
-            FileInfo fi = new FileInfo(Process.GetCurrentProcess().MainModule.FileName);
-            Program.Directory = fi.DirectoryName;
-            string xmlFile = Path.Combine(Program.Directory, "PBE.xml");
-            Console.WriteLine(xmlFile);
-            new ExecutableContainer(XElement.Load(xmlFile)).Execute();
+        private static void RunPBE(CommandLineOptions options)
+        {
+            PBEContext.Create(options);
+            new ExecutableContainer(options).Execute();
         }
     }
 }

--- a/src/PBE/packages.config
+++ b/src/PBE/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommandLineParser" version="2.3.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Hallo,

ich habe eine Bibliothek für die Verarbeitung von Kommandozeilenparametern eingebaut und dabei die Möglichkeit geschaffen, die Konfigurationsdatei und das Logging-Verzeichnis als Parameter zu übergeben. Dadurch kann PBE zentral hinterlegt werden, was ein Update vereinfacht. Die Implementierung sollte abwärtskompatibel sein. 

Außerdem habe ich einen Typo in der Programmausgabe behoben und das Condition-Element um ein Funktionshandling erweitert. Aktuell gibt es eine Funktion #Exists(...) der ein Pfad übergeben werden kann. Dieser wird dann zum Zeitpunkt der Ausführung der Action evaluiert. Ich habe ausführliche Checkin-Kommentare angegeben.

Ich denke, diese Änderungen sind für den Standard interessant.