### PR TITLE
Bugfix: Indexfehler bei fehlerhaftem Filterparameter

### DIFF
--- a/src/PBE/CommandLineProcessor/CommandLineParser.cs
+++ b/src/PBE/CommandLineProcessor/CommandLineParser.cs
@@ -25,7 +25,7 @@ namespace PBE.CommandLineProcessor
 
             for (int i = 0; i < args.Length; i++)
             {
-                if ("/AUTO".Equals(args[i], StringComparison.OrdinalIgnoreCase))
+                if ("AUTO".Equals(args[i], StringComparison.OrdinalIgnoreCase))
                 {
                     modifiedArgs.Add("--auto");
                 }

--- a/src/PBE/CommandLineProcessor/CommandLineParser.cs
+++ b/src/PBE/CommandLineProcessor/CommandLineParser.cs
@@ -31,7 +31,7 @@ namespace PBE.CommandLineProcessor
                 }
                 else if ("/FILTER".Equals(args[i], StringComparison.OrdinalIgnoreCase))
                 {
-                    if (i <= args.Length)
+                    if (i < args.Length-1)
                     {
                         filters.Add(args[++i]);
                     }

--- a/src/PBE/CommandLineProcessor/CommandLineParser.cs
+++ b/src/PBE/CommandLineProcessor/CommandLineParser.cs
@@ -25,7 +25,7 @@ namespace PBE.CommandLineProcessor
 
             for (int i = 0; i < args.Length; i++)
             {
-                if ("AUTO".Equals(args[i], StringComparison.OrdinalIgnoreCase))
+                if ("/AUTO".Equals(args[i], StringComparison.OrdinalIgnoreCase))
                 {
                     modifiedArgs.Add("--auto");
                 }


### PR DESCRIPTION
In meinen Änderungen hat sich bei der Verarbeitung der Indexinformation ein Fehler eingeschlichen. Es kommt zu einer IndexOutOfRangeException wenn der alte FILTER-Parameter ohne Argument verwendet wird. Das habe ich jetzt behoben.