### PR TITLE
Bug 2025047734: Problem beim Export der Onlinehilfe 4.7.1 (PBE), lang…

### DIFF
--- a/src/PBE/Actions/ExportDoc.cs
+++ b/src/PBE/Actions/ExportDoc.cs
@@ -39,7 +39,13 @@ namespace PBE.Actions
                 Dir = container.ParseParameters("{" + this.ExportDirParameter + "}");
             }
 
-            string folder = Path.Combine(this.Dir, container.CreateExportFileName(this.Package, this.Version) + "_Help_" + this.Iso);
+            string folder = this.Dir;
+
+            // Ab Version 4.6 kümmert sich FS selber um einen sprechenden Unter-Ordner.
+            if (FSVer < new Version(4, 6))
+            {
+                folder = Path.Combine(folder, container.CreateExportFileName(this.Package, this.Version) + "_Help_" + this.Iso);
+            }
 
             var args = new List<string>()
             {


### PR DESCRIPTION
…e Ordner

ein PBE.xml zum Testen:

```xml
<?xml version="1.0" encoding="utf-8" ?>
<!DOCTYPE PBE SYSTEM "PBE.dtd">
<PBE Logfile="C:\temp\Log.html" Logarchive="C:\temp\Archive\Log_{DateTime}.html">

  <Params>
    <Param Name="ExportDir" Value="C:\Temp\PBE2\export\" />
    <Param Name="rep45" Value="\ConnectionType SqlServer \Server NV324 \Database FSDemo45" />
    <Param Name="rep46" Value="\ConnectionType SqlServer \Server NV324 \Database FSDemo46" />
    <Param Name="rep47" Value="\ConnectionType SqlServer \Server NV324 \Database FSDemo47" />
  </Params>

  <Sequence>
    <RD Name="letztes Export-Dir löschen" Dir="{ExportDir}" />
    <MD Name="Export-Dir neu anlegen" Dir="{ExportDir}" />

    <Parallel Name="Doku-Export">
      <ExportDoc FS="4.5.0.0" Rep="{rep45}" Package="FSDemo" Version="4.5" Iso="de" Dir="{ExportDir}\Help"/>
      <ExportDoc FS="4.6.0.0" Rep="{rep46}" Package="FSDemo" Version="4.6" Iso="de" Dir="{ExportDir}\Help"/>
      <ExportDoc FS="4.7.0.0" Rep="{rep47}" Package="FSDemo" Version="4.7" Iso="de" Dir="{ExportDir}\Help"/>
    </Parallel>
  </Sequence>
</PBE>
```

Ausgabe der Ordner nach der Korrektur:
![image](https://github.com/user-attachments/assets/e1738702-3284-4acd-b2ae-263f7baba2fc)
