### PR TITLE
Improve FSVersion parsing error handling

### DIFF
--- a/src/PBE/Actions/FSConsole.cs
+++ b/src/PBE/Actions/FSConsole.cs
@@ -12,10 +12,7 @@ namespace PBE.Actions
         {
             this.FSVersionString = container.ParseParameters(xe.Attribute("FS").Value);
 
-            if (FSVersion.TryParse(this.FSVersionString, out FSVersion fsVer))
-            {
-                this.FSVer = fsVer;
-            }
+            FSVer = new FSVersion(FSVersionString);
 
             // nicht parsen - wird erst im Execute geparsed
             this.Rep = xe.Attribute("Rep").Value;

--- a/src/PBE/Utils/FSVersion.cs
+++ b/src/PBE/Utils/FSVersion.cs
@@ -11,7 +11,7 @@ namespace PBE.Utils
         {
             if (string.IsNullOrWhiteSpace(version))
             {
-                throw new ArgumentException("Version string cannot be null or empty.", nameof(version));
+                throw new ArgumentException("FSVersion string must not be null or empty.", nameof(version));
             }
 
             if (version.EndsWith(".pre", StringComparison.OrdinalIgnoreCase))
@@ -30,7 +30,7 @@ namespace PBE.Utils
             }
             else
             {
-                throw new ArgumentException($"Version String {version} could not be Parsed!");
+                throw new ArgumentException($"FSVersion string {version} could not be parsed!{Environment.NewLine}Please correct your xml definition.");
             }
         }
 


### PR DESCRIPTION
Enhance error messages in FSVersion parsing to provide clearer feedback and prevent unhandled exceptions. This change addresses a potential NullReferenceException by ensuring that exceptions are properly thrown and informative.